### PR TITLE
PAWQ-153: Error boton enviar en comentarios

### DIFF
--- a/src/infrastructure/react-native/components/CommentSection.tsx
+++ b/src/infrastructure/react-native/components/CommentSection.tsx
@@ -39,6 +39,7 @@ export function CommentSection({ onDismiss, visible, onAddComment, pubId }: Comm
 	const theme = useTheme();
 	const styles = createStyles(theme);
 	const [loading, setLoading] = useState<boolean>(false);
+	const [commentState, setCommentState] = useState<string | undefined>(undefined);
 
 	const {
 		control,
@@ -80,9 +81,15 @@ export function CommentSection({ onDismiss, visible, onAddComment, pubId }: Comm
 		if (onAddComment !== undefined) {
 			onAddComment(addCommentRequest, {
 				onSuccess: () => {
-					setLoading(false);
 					reset();
 					refetch();
+					setCommentState('Success');
+				},
+				onError: () => {
+					setCommentState('Error');
+				},
+				onSettled: () => {
+					setLoading(false);
 				}
 			});
 		}
@@ -182,24 +189,32 @@ export function CommentSection({ onDismiss, visible, onAddComment, pubId }: Comm
 							name="comment_text"
 						/>
 
-						<IconButton
-							icon="send-circle"
-							size={45}
-							iconColor={theme.colors.primary}
-							onPress={handleSubmit(onSubmitComment)}
-							disabled={loading}
-						/>
+						{loading ? (
+							<ActivityIndicator size={45} style={styles.activityIndicator} />
+						) : (
+							<IconButton
+								icon="send-circle"
+								size={45}
+								iconColor={theme.colors.primary}
+								onPress={handleSubmit(onSubmitComment)}
+							/>
+						)}
 					</View>
 				</View>
 			</View>
 			<Snackbar
 				theme={theme}
-				visible={false}
-				onDismiss={() => reset()}
+				visible={commentState !== undefined}
+				onDismiss={() => setCommentState(undefined)}
+				onIconPress={() => setCommentState(undefined)}
 				duration={2000}
-				style={{ marginBottom: 150 }}
+				style={styles.snackbarStyle}
+				icon="close"
 			>
-				Comentario agregado
+				<Text style={styles.snackbarText}>
+					{commentState === 'Error' && 'Error al agregar el comentario. Intente de nuevo...'}
+					{commentState === 'Success' && '¡Comentario agregado correctamente!'}
+				</Text>
 			</Snackbar>
 		</Modal>
 	);
@@ -273,5 +288,13 @@ const createStyles = (theme: MD3Theme) =>
 		errorText: {
 			marginTop: -10,
 			marginBottom: 10
+		},
+		snackbarStyle: {
+			width: '90%',
+			alignSelf: 'center',
+			marginBottom: 100
+		},
+		snackbarText: {
+			color: theme.colors.secondary
 		}
 	});


### PR DESCRIPTION
- Ahora el botón de agregar comentario está disponible después de un error.
- Se agregó una animación de "carga" (loading) mientras el comentario se envía